### PR TITLE
Fix a problem where the wrong grid point can be selected in cases where

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## NOTE - The products produced by this software have not been validated and are considered prototype.
 
-## Land Surface Temperature 0.3.0 Release Notes
-Release Date: June 2017
+## Land Surface Temperature 0.3.1 Release Notes
+Release Date: August 2017
 
-See git tag [lst-rit-v0.3.0]
+See git tag [lst-rit-v0.3.1]
 
 This project contains application source code for producing Land Surface Temperature products.
 
@@ -12,12 +12,8 @@ See the [provisional_st_README_V10.pdf](https://edclpdsftp.cr.usgs.gov/downloads
 
 ## Release Notes
 * Version change
-* Update to only compute parameters for elevations used for the scene.  This
-  results in shorter run times, particularly for scenes without large elevation
-  changes.
-* An error with the data type of the Landsat 8 input thermal data was 
-  corrected. 
- 
+* Fix a problem where if 2 or more grid points have the same distance to a 
+  pixel, the wrong grid point (farther from the pixel) could be selected.
 
 ## Installation
 

--- a/not-validated-prototype_lst/scripts/lst_utilities.py
+++ b/not-validated-prototype_lst/scripts/lst_utilities.py
@@ -27,7 +27,7 @@ class Version(object):
         Provides methods for retrieving version information.
     '''
 
-    version = '0.3.0'
+    version = '0.3.1'
 
     @staticmethod
     def version_number():

--- a/not-validated-prototype_lst/src/calculate_atmospheric_parameters.c
+++ b/not-validated-prototype_lst/src/calculate_atmospheric_parameters.c
@@ -1680,15 +1680,12 @@ int calculate_pixel_atmospheric_parameters
                 { /* LL Cell */
                     cell_vertices[LL_POINT] = center_point - 1 - num_cols;
                 }
-                else if (avg_distance_ul < avg_distance_ll
-                    && avg_distance_ul < avg_distance_ur
+                else if (avg_distance_ul < avg_distance_ur
                     && avg_distance_ul < avg_distance_lr)
                 { /* UL Cell */
                     cell_vertices[LL_POINT] = center_point - 1;
                 }
-                else if (avg_distance_ur < avg_distance_ll
-                    && avg_distance_ur < avg_distance_ul
-                    && avg_distance_ur < avg_distance_lr)
+                else if (avg_distance_ur < avg_distance_lr)
                 { /* UR Cell */
                     cell_vertices[LL_POINT] = center_point;
                 }

--- a/not-validated-prototype_lst/src/const.h
+++ b/not-validated-prototype_lst/src/const.h
@@ -6,7 +6,7 @@
 #include <math.h>
 
 
-#define LST_VERSION "0.3.0"
+#define LST_VERSION "0.3.1"
 #define LST_NO_DATA_VALUE (-9999.0)
 
 


### PR DESCRIPTION
some grid points have the same distance to a pixel.  The closest grid point
should be selected.  For example, if 2 are the same distance and they are
the closest, one of them should be selected, but that was not happening.  In
addition to being non-optimal for interpolation, as a result, in some cases
points that had not had MODTRAN run were selected, causing uninitialized
memory to be used.  This was observed in 2 different scenes, 1 pixel each.